### PR TITLE
feat(fetch): add real estate support

### DIFF
--- a/finalynx/fetch/finary_fetch.py
+++ b/finalynx/fetch/finary_fetch.py
@@ -100,9 +100,7 @@ def finary_fetch(portfolio, force_signin=False, ignore_orphans=False):
                 "fonds_euro",
                 "startups",
                 "precious_metals",
-                "scpis",
                 "generic_assets",
-                "real_estates",
                 "loans",
                 "crowdlendings",
             ]:
@@ -115,6 +113,32 @@ def finary_fetch(portfolio, force_signin=False, ignore_orphans=False):
                         ignore_orphans,
                         indent=2,
                     )
+
+        # Immobilier
+        console.log("Fetching real estate...")
+        real_estate = ff.get_real_estates(session, "1w")["result"]
+        f_re_total = round(real_estate["total"]["amount"])
+        node = tree.add("[bold]" + str(round(f_re_total)) + " Immobilier")
+
+        for item in real_estate["data"]["real_estates"]:
+            match_line(
+                portfolio,
+                item["description"],
+                item["current_value"],
+                node,
+                ignore_orphans,
+                indent=1,
+            )
+
+        for item in real_estate["data"]["scpis"]:
+            match_line(
+                portfolio,
+                item["scpi"]["name"],
+                item["current_value"],
+                node,
+                ignore_orphans,
+                indent=1,
+            )
 
     # Delete login variables just in case
     if os.environ.get("FINARY_EMAIL"):


### PR DESCRIPTION
# Subject

Add basic support for real estate assets.

# Implem

I just used finary_api.get_real_estates.

I removed the `scpis` and `real_estates` items from the `category` list because I assume they are invalid, but I might be wrong.

# Tests

Tested with 2 asset types:
- "hard" real estate
- SCPI

Result:

```
│ 187892 Immobilier                                                            │
│ ├── 177400 Appart principal                                                  │
│ │   └── WARNING: This line did not match with any envelope, attaching to     │
│ │       root                                                                 │
│ ├── 187 Novaxia Neo                                                          │
│ │   └── WARNING: This line did not match with any envelope, attaching to     │
│ │       root                                                                 │
│ └── 10305 Remake Live                                                        │
╰──────────────────────────────────────────────────────────────────────────────╯
```