### PR TITLE
feat(portfolio): basic support for multi-currencies

### DIFF
--- a/finalynx/assistant.py
+++ b/finalynx/assistant.py
@@ -209,7 +209,11 @@ class Assistant:
             children, env_delta = [], 0.0
             for line in env.lines:
                 delta = line.get_delta()
-                if delta != 0 and line.target.check() not in [Target.RESULT_NONE, Target.RESULT_OK]:
+                if delta != 0 and line.target.check() not in [
+                    Target.RESULT_NONE,
+                    Target.RESULT_OK,
+                    Target.RESULT_TOLERATED,
+                ]:
                     env_delta += delta
                     children.append(line.render(output_format="[delta][name]"))
 

--- a/finalynx/fetch/fetch_finary.py
+++ b/finalynx/fetch/fetch_finary.py
@@ -219,14 +219,20 @@ class FetchFinary(Fetch):  # TODO update docstrings
                 self._match_line(lines_list, node, key, id, round(amount))
 
         # Process similar sources together
-        _process("Checkings", ff.get_checking_accounts, lambda e: (e["name"], e["id"], e["fiats"][0]["current_value"]))
-        _process("Savings", ff.get_savings_accounts, lambda e: (e["name"], e["id"], e["fiats"][0]["current_value"]))
-        _process("Fonds euro", ff.get_fonds_euro, lambda e: (e["name"], e["id"], e["current_value"]))
-        _process("Others", ff.get_other_assets, lambda e: (e["name"], e["id"], e["current_value"]))
+        _process(
+            "Checkings",
+            ff.get_checking_accounts,
+            lambda e: (e["name"], e["id"], e["fiats"][0]["display_current_value"]),
+        )
+        _process(
+            "Savings", ff.get_savings_accounts, lambda e: (e["name"], e["id"], e["fiats"][0]["display_current_value"])
+        )
+        _process("Fonds euro", ff.get_fonds_euro, lambda e: (e["name"], e["id"], e["display_current_value"]))
+        _process("Others", ff.get_other_assets, lambda e: (e["name"], e["id"], e["display_current_value"]))
         _process(
             "Precious metals",
             ff.get_user_precious_metals,
-            lambda e: (e["precious_metal"]["name"], e["id"], e["current_value"]),
+            lambda e: (e["precious_metal"]["name"], e["id"], e["display_current_value"]),
             period=False,
         )
 
@@ -242,7 +248,7 @@ class FetchFinary(Fetch):  # TODO update docstrings
                     node_account,
                     key=account["security"]["name"],
                     id=account["id"],
-                    amount=account["current_value"],
+                    amount=account["display_current_value"],
                 )
 
         # Cryptos
@@ -258,7 +264,7 @@ class FetchFinary(Fetch):  # TODO update docstrings
                     node_account,
                     key=account["crypto"]["name"],
                     id=account["id"],
-                    amount=account["current_value"],
+                    amount=account["display_current_value"],
                 )
 
         # Real estate
@@ -267,10 +273,12 @@ class FetchFinary(Fetch):  # TODO update docstrings
         real_estate = ff.get_real_estates(session, "1w")["result"]
 
         for item in real_estate["data"]["real_estates"]:
-            self._match_line(lines_list, node, key=item["description"], id=item["id"], amount=item["current_value"])
+            self._match_line(
+                lines_list, node, key=item["description"], id=item["id"], amount=item["display_current_value"]
+            )
         for item in real_estate["data"]["scpis"]:
             self._match_line(
-                lines_list, node, key=item["scpi"]["name"], id=item["scpi"]["id"], amount=item["current_value"]
+                lines_list, node, key=item["scpi"]["name"], id=item["scpi"]["id"], amount=item["display_current_value"]
             )
 
         return lines_list, tree

--- a/finalynx/portfolio/folder.py
+++ b/finalynx/portfolio/folder.py
@@ -89,8 +89,8 @@ class Folder(Node):
         return float(np.sum([child.get_amount() for child in self.children]) if self.children else 0)
 
     def get_currency(self) -> str:
-        """:returns: This node's currency symbol, equal to it's chidlren common currency.
-        If children have different currencies, return an unknown currency (TODO to be improved)."""
+        """:returns: This folder's currency symbol, equal to its children common currency.
+        If children have different currencies, return an unknown symbol (TODO to be improved)."""
         currencies = [c.get_currency() for c in self.children]
         if currencies and currencies.count(currencies[0]) == len(currencies):
             return currencies[0]
@@ -353,7 +353,11 @@ class Portfolio(Folder):
     """This is the root of your custom portfolio hierarchy."""
 
     def __init__(
-        self, name: str = "Portfolio", target: Optional["Target"] = None, children: Optional[List["Node"]] = None
+        self,
+        name: str = "Portfolio",
+        target: Optional["Target"] = None,
+        children: Optional[List["Node"]] = None,
+        currency: Optional[str] = None,
     ):
         """
         This class is actually nothing more than a normal `Folder` renamed to `Portfolio` for user clarity
@@ -366,7 +370,7 @@ class Portfolio(Folder):
         :param children: List of `Line`, `Folder`, and `SharedFolder` objects to recursively define the
         entire structure, defaults to an empty list.
         """
-        super().__init__(name, parent=None, target=target, children=children, newline=False)
+        super().__init__(name, parent=None, target=target, children=children, newline=False, currency=currency)
 
     @staticmethod
     def from_dict(dict: Dict[str, Any], buckets: Dict[str, Bucket], envelopes: Dict[str, Envelope]) -> "Portfolio":

--- a/finalynx/portfolio/folder.py
+++ b/finalynx/portfolio/folder.py
@@ -45,6 +45,7 @@ class Folder(Node):
         newline: bool = False,
         display: FolderDisplay = FolderDisplay.EXPANDED,
         perf: Optional[LinePerf] = None,
+        currency: Optional[str] = None,
     ):
         """
         This class handles the orchestration of rendering of its children.
@@ -71,7 +72,7 @@ class Folder(Node):
         for child in self.children:
             child.set_parent(self)
 
-        self.set_children(asset_class, perf)
+        self.set_children_attribs(asset_class, perf, currency)
 
     def add_child(self, child: Node) -> None:
         """Manually add a child at the end of the existing children in this folder.
@@ -86,6 +87,14 @@ class Folder(Node):
         :returns: The sum of what each child's `get_amount()` method returns.
         """
         return float(np.sum([child.get_amount() for child in self.children]) if self.children else 0)
+
+    def get_currency(self) -> str:
+        """:returns: This node's currency symbol, equal to it's chidlren common currency.
+        If children have different currencies, return an unknown currency (TODO to be improved)."""
+        currencies = [c.get_currency() for c in self.children]
+        if currencies and currencies.count(currencies[0]) == len(currencies):
+            return currencies[0]
+        return "?"
 
     def get_ideal(self) -> float:
         """:returns: The ideal amount to be invested in this node based on surrounding targets."""
@@ -200,15 +209,16 @@ class Folder(Node):
                 success = True
         return success
 
-    def set_children(self, asset_class: AssetClass, perf: Optional[LinePerf]) -> None:
+    def set_children_attribs(self, asset_class: AssetClass, perf: Optional[LinePerf], currency: Optional[str]) -> None:
         """Used at initialization time by Folders to set attributes once in the Folder
         instead of setting it in each child."""
         for child in self.children:
             if isinstance(child, Line):
                 child.asset_class = asset_class if child.asset_class is AssetClass.UNKNOWN else child.asset_class
                 child.perf = perf if perf and child.perf.expected == 0 else child.perf
+                child.currency = currency if currency else child.currency
             elif isinstance(child, Folder):
-                child.set_children(asset_class, perf)
+                child.set_children_attribs(asset_class, perf, currency)
             else:
                 raise ValueError("Unrecognized node type.")
 

--- a/finalynx/portfolio/line.py
+++ b/finalynx/portfolio/line.py
@@ -28,6 +28,7 @@ class Line(Node):
         newline: bool = False,
         envelope: Optional["Envelope"] = None,
         perf: Optional[LinePerf] = None,
+        currency: str = "€",
     ):
         """
         This is a subclass of `Node` that adds an `amount` and `key` property.
@@ -47,7 +48,7 @@ class Line(Node):
             "account_code": self._render_account_code,
         }
 
-        super().__init__(name, parent, target, newline, agents=render_agents)
+        super().__init__(name, parent, target, newline, agents=render_agents, currency=currency)
         self.asset_class = asset_class
         self.key = key if key is not None else name
         self.amount = amount
@@ -81,6 +82,7 @@ class Line(Node):
             "envelope_name": self.envelope.name if self.envelope else "",
             "perf": self.perf.__dict__,
             "newline": self.newline,
+            "currency": self.currency,
         }
 
     @staticmethod
@@ -94,4 +96,5 @@ class Line(Node):
             envelope=envelopes[dict["envelope_name"]] if dict["envelope_name"] else None,
             perf=LinePerf.from_dict(dict["perf"]),
             newline=bool(dict["newline"]),
+            currency=dict["currency"] if "currency" in dict.keys() else "€",
         )

--- a/finalynx/portfolio/node.py
+++ b/finalynx/portfolio/node.py
@@ -27,6 +27,7 @@ class Node(Hierarchy, Render):
         newline: bool = False,
         aliases: Optional[Dict[str, str]] = None,
         agents: Optional[Dict[str, Callable[..., str]]] = None,
+        currency: str = "€",
     ):
         """This is an abstract class used by the `Line` and `Folder` subclasses.
 
@@ -44,6 +45,7 @@ class Node(Hierarchy, Render):
         self.newline = newline
         self.target = target if target is not None else Target()
         self.target.set_parent(self)
+        self.currency = currency
 
         if target is not None:
             target.set_parent(self)
@@ -97,6 +99,10 @@ class Node(Hierarchy, Render):
         """:returns: The expected yearly performance of this node."""
         raise NotImplementedError("Must be overridden by children classes")
 
+    def get_currency(self) -> str:
+        """:returns: This node's currency symbol."""
+        return self.currency
+
     def tree(
         self,
         output_format: str = "[console]",
@@ -132,7 +138,7 @@ class Node(Hierarchy, Render):
 
     def _render_currency(self) -> str:
         """:returns: A formatted rendering of this element's currency."""
-        return "€"  # TODO add multi-currency support?
+        return self.get_currency()
 
     def _render_hint(self) -> str:
         """:returns: A formatted rendering of a hint message (at the end by default)."""


### PR DESCRIPTION
### Description
Let the user set its own currency symbol. Several options:
- `Line(..., currency="$")` to set a single line's currency
- `Folder(..., currency="$")` to set every children's currency at once (used as a shortcut)
- `Portfolio(..., currency="$")` to set the default global currency everywhere

Changes made in a child take priority over a change made in a parent.

### Actions
- Closes #54 

### Steps
- [X] Set the currency symbol for an individual node
- [X] Set the currency of every children in a Folder
- [ ] Behavior when a Folder has multiple currencies? ➡ For now, simply write a '?' symbol
- [x] Create a global Finalynx config with a default currency symbol? ➡ no need for now, simply set the Portfolio's currency
