### PR TITLE
fix(fetch): ignoring invalid elements from API response

### DIFF
--- a/finalynx/fetch/fetch_finary.py
+++ b/finalynx/fetch/fetch_finary.py
@@ -104,7 +104,11 @@ class FetchFinary(Fetch):  # TODO update docstrings
             if not session:
                 return Tree("Finary signin failed.")
 
-            lines_list, tree = self._fetch_data(session, tree)
+            try:
+                lines_list, tree = self._fetch_data(session, tree)
+            except Exception:
+                console.log("[red bold]Error: Couldn't fetch data, please try using the `-f` option to signin again.")
+                return tree
 
             # Save what has been found in a cache file for offline use and better performance at next launch
             self._save_cache(lines_list)

--- a/finalynx/fetch/fetch_finary.py
+++ b/finalynx/fetch/fetch_finary.py
@@ -104,11 +104,7 @@ class FetchFinary(Fetch):  # TODO update docstrings
             if not session:
                 return Tree("Finary signin failed.")
 
-            try:
-                lines_list, tree = self._fetch_data(session, tree)
-            except Exception:
-                console.log("[red bold]Error: Couldn't fetch data, please try using the `-f` option to signin again.")
-                return tree
+            lines_list, tree = self._fetch_data(session, tree)
 
             # Save what has been found in a cache file for offline use and better performance at next launch
             self._save_cache(lines_list)
@@ -305,6 +301,10 @@ class FetchFinary(Fetch):  # TODO update docstrings
 
     def _match_line(self, lines_list: List[Dict[str, Any]], node: Tree, key: str, id: str, amount: int) -> None:
         """Internal method used to register a new investment found from Finary."""
+
+        if not key or not id:
+            console.log("[yellow][bold]WARNING:[/] Invalid element in the API response, skipping.")
+            return
 
         # Discard non-ASCII characters in the key
         key, id, amount = unidecode(key), str(id), round(amount)


### PR DESCRIPTION
### Description
When Finary API return invalid elements (i.e. missing name, id) it returns an error and stop fetching.

### Actions
- Resolves #63 

### Implementation
Ignoring element when missing key or id from API response.

