### PR TITLE
feat(console): add option to change the console render theme

### DIFF
--- a/finalynx/__init__.py
+++ b/finalynx/__init__.py
@@ -34,6 +34,9 @@ from .simulator import Simulator
 # Main
 from .assistant import Assistant
 
+# Themes
+from .theme import Theme, LightTheme, DarkTheme
+
 # Enable rich's features
 from rich import print, inspect, pretty, traceback
 from rich.tree import Tree

--- a/finalynx/assistant.py
+++ b/finalynx/assistant.py
@@ -11,6 +11,7 @@ from docopt import docopt
 from finalynx import Dashboard
 from finalynx import Fetch
 from finalynx import Portfolio
+from finalynx.config import ACTIVE_THEME as TH
 from finalynx.fetch.source_base import SourceBase
 from finalynx.fetch.source_finary import SourceFinary
 from finalynx.portfolio.bucket import Bucket
@@ -193,8 +194,20 @@ class Assistant:
 
         # Final set of results to be displayed
         panels: List[ConsoleRenderable] = [
-            Panel(self.render_envelopes(), title="Delta Investments", padding=(1, 2), expand=False),
-            Panel(self.render_perf(), title="Performance", padding=(1, 2), expand=False),
+            Panel(
+                self.render_envelopes(),
+                title="Delta Investments",
+                padding=(1, 2),
+                expand=False,
+                border_style=TH.PANEL,
+            ),
+            Panel(
+                self.render_perf(),
+                title="Performance",
+                padding=(1, 2),
+                expand=False,
+                border_style=TH.PANEL,
+            ),
         ]
 
         # Show the data fetched from Finary if specified
@@ -225,14 +238,14 @@ class Assistant:
         perf_ideal = self.portfolio.get_perf(ideal=True).expected
 
         tree = Tree("Global Performance", hide_root=True)
-        tree.add(f"Current:  [bold][green]{perf:.1f} %[/] / year")
-        tree.add(f"Planned:  [bold][green]{perf_ideal:.1f} %[/] / year")
+        tree.add(f"[{TH.TEXT}]Current:  [bold][{TH.ACCENT}]{perf:.1f} %[/] / year")
+        tree.add(f"[{TH.TEXT}]Planned:  [bold][{TH.ACCENT}]{perf_ideal:.1f} %[/] / year")
         return tree
 
     def render_envelopes(self) -> Tree:
         """Sort lines with non-zero deltas by envelopes and display them as
         a summary of transfers to make."""
-        tree = Tree("Envelopes", hide_root=True)
+        tree = Tree("Envelopes", hide_root=True, guide_style=TH.TREE_BRANCHES)
 
         for env in self.envelopes:
             children, env_delta = [], 0.0
@@ -244,12 +257,12 @@ class Assistant:
                     Target.RESULT_TOLERATED,
                 ]:
                     env_delta += delta
-                    children.append(line._render_delta(children=env.lines) + line._render_name())  # type: ignore
+                    children.append(f"[{TH.TEXT}]" + line._render_delta(children=env.lines) + line._render_name())  # type: ignore
 
             if children:
                 env_delta = round(env_delta)
-                render_delta = f"[{'green' if env_delta > 0 else 'red'}]{'+' if env_delta > 0 else ''}{env_delta} {finalynx.config.DEFAULT_CURRENCY}"
-                node = tree.add(f"{render_delta} [dodger_blue2 bold]{env.name}[/]")
+                render_delta = f"[{TH.DELTA_POS if env_delta > 0 else TH.DELTA_NEG}]{'+' if env_delta > 0 else ''}{env_delta} {finalynx.config.DEFAULT_CURRENCY}"
+                node = tree.add(f"{render_delta} [{TH.FOLDER_COLOR} {TH.FOLDER_STYLE}]{env.name}[/]")
                 for child in children:
                     node.add(child)
                 node.children[-1].label += "\n"  # type: ignore
@@ -268,10 +281,10 @@ class Assistant:
 
         folders = _get_folders(self.portfolio)
         if folders:
-            node = tree.add("[dodger_blue2 bold]Folders")
+            node = tree.add(f"[{TH.FOLDER_COLOR} {TH.FOLDER_STYLE}]Folders")
             for f in folders:
                 if f.get_delta() != 0:
-                    node.add(f._render_delta(children=folders) + f._render_name())  # type: ignore
+                    node.add(f"[{TH.TEXT}]" + f._render_delta(children=folders) + f._render_name())  # type: ignore
         return tree
 
     def export(self, dirpath: str) -> None:

--- a/finalynx/assistant.py
+++ b/finalynx/assistant.py
@@ -5,11 +5,12 @@ from typing import List
 from typing import Optional
 from typing import TYPE_CHECKING
 
+import finalynx.config
+import finalynx.theme
 from docopt import docopt
 from finalynx import Dashboard
 from finalynx import Fetch
 from finalynx import Portfolio
-from finalynx.config import DEFAULT_CURRENCY
 from finalynx.fetch.source_base import SourceBase
 from finalynx.fetch.source_finary import SourceFinary
 from finalynx.portfolio.bucket import Bucket
@@ -26,6 +27,7 @@ from rich.columns import Columns
 from rich.panel import Panel
 from rich.text import Text
 from rich.tree import Tree
+
 
 if TYPE_CHECKING:
     from rich.console import ConsoleRenderable
@@ -74,6 +76,7 @@ class Assistant:
         enable_export: bool = True,
         export_dir: str = "logs",
         active_sources: Optional[List[str]] = None,
+        theme: Optional[finalynx.theme.Theme] = None,
         ignore_argv: bool = False,
     ):
         self.portfolio = portfolio
@@ -93,6 +96,7 @@ class Assistant:
         self.enable_export = enable_export
         self.export_dir = export_dir
         self.active_sources = active_sources if active_sources else ["finary"]
+        finalynx.config.ACTIVE_THEME = theme if theme else finalynx.config.ACTIVE_THEME
 
         # Unless disabled, parse the command line options as an additional source of settings
         if not ignore_argv:
@@ -147,6 +151,11 @@ class Assistant:
             self.export_dir = args["--export-dir"]
         if args["--sources"]:
             self.active_sources = str(args["--sources"]).split(",")
+        if args["--theme"]:
+            theme_name = str(args["--theme"])
+            if theme_name not in finalynx.theme.AVAILABLE_THEMES:
+                raise ValueError("Theme name options: " + ", ".join(finalynx.theme.AVAILABLE_THEMES.keys()))
+            finalynx.config.ACTIVE_THEME = finalynx.theme.AVAILABLE_THEMES[theme_name]()
 
     def run(self) -> None:
         """Main function to run once your configuration is fully defined.
@@ -239,7 +248,7 @@ class Assistant:
 
             if children:
                 env_delta = round(env_delta)
-                render_delta = f"[{'green' if env_delta > 0 else 'red'}]{'+' if env_delta > 0 else ''}{env_delta} {DEFAULT_CURRENCY}"
+                render_delta = f"[{'green' if env_delta > 0 else 'red'}]{'+' if env_delta > 0 else ''}{env_delta} {finalynx.config.DEFAULT_CURRENCY}"
                 node = tree.add(f"{render_delta} [dodger_blue2 bold]{env.name}[/]")
                 for child in children:
                     node.add(child)

--- a/finalynx/config.py
+++ b/finalynx/config.py
@@ -8,4 +8,15 @@ from .theme import Theme
 DEFAULT_CURRENCY = "€"
 
 # Hold the active theme used, defaults to light theme
-ACTIVE_THEME: Theme = LightTheme()
+_active_theme: Theme = LightTheme()
+
+
+def set_active_theme(theme: Theme) -> None:
+    """Setter method needed to pass elements by reference accross modules."""
+    global _active_theme
+    _active_theme = theme
+
+
+def get_active_theme() -> Theme:
+    """Getter method needed to pass elements by reference accross modules."""
+    return _active_theme

--- a/finalynx/config.py
+++ b/finalynx/config.py
@@ -1,5 +1,11 @@
 """
 This file is where Finalynx's overall behavior can be customized.
 """
+from .theme import LightTheme
+from .theme import Theme
 
-DEFAULT_CURRENCY = "€"  # When the currency symbol is not specified in the user config, use this symbol
+# When the currency symbol is not specified in the user config, use this symbol
+DEFAULT_CURRENCY = "€"
+
+# Hold the active theme used, defaults to light theme
+ACTIVE_THEME: Theme = LightTheme()

--- a/finalynx/fetch/source_base.py
+++ b/finalynx/fetch/source_base.py
@@ -9,7 +9,7 @@ from typing import Optional
 from rich.tree import Tree
 from unidecode import unidecode
 
-from ..config import ACTIVE_THEME as TH
+from ..config import get_active_theme as TH
 from ..console import console
 from ..portfolio import Line
 from ..portfolio import Portfolio
@@ -128,7 +128,7 @@ class SourceBase:
         name, id, account, amount = unidecode(name), str(id), unidecode(account), round(float(amount))
 
         # Add the line to the rendering tree
-        tree_node.add(f"{amount} {currency} {name} [{TH.HINT}]{id=}")
+        tree_node.add(f"{amount} {currency} {name} [{TH().HINT}]{id=}")
 
         # Form a FetLine instance from the information given and return it
         self._fetched_lines.append(

--- a/finalynx/fetch/source_base.py
+++ b/finalynx/fetch/source_base.py
@@ -9,6 +9,7 @@ from typing import Optional
 from rich.tree import Tree
 from unidecode import unidecode
 
+from ..config import ACTIVE_THEME as TH
 from ..console import console
 from ..portfolio import Line
 from ..portfolio import Portfolio
@@ -127,7 +128,7 @@ class SourceBase:
         name, id, account, amount = unidecode(name), str(id), unidecode(account), round(float(amount))
 
         # Add the line to the rendering tree
-        tree_node.add(f"{amount} {currency} {name} [dim white]{id=}")
+        tree_node.add(f"{amount} {currency} {name} [{TH.HINT}]{id=}")
 
         # Form a FetLine instance from the information given and return it
         self._fetched_lines.append(

--- a/finalynx/fetch/source_finary.py
+++ b/finalynx/fetch/source_finary.py
@@ -11,6 +11,7 @@ from requests import Session
 from rich.prompt import Confirm
 from rich.tree import Tree
 
+from ..config import ACTIVE_THEME as TH
 from ..console import console
 from .source_base import SourceBase
 
@@ -125,7 +126,7 @@ class SourceFinary(SourceBase):
 
         # Login to Finary with the existing cookies file or credentials in environment variables and retrieve data
         if os.environ.get("FINARY_EMAIL") and os.environ.get("FINARY_PASSWORD"):
-            with console.status("[bold green]Signing in to Finary..."):
+            with console.status(f"[bold {TH.ACCENT}]Signing in to Finary...", spinner_style=TH.ACCENT):
                 result = ff.signin()
                 console.log("Signed in to Finary.")
 
@@ -168,7 +169,7 @@ class SourceFinary(SourceBase):
             raise ValueError("Finary signin failed.")
 
         # Call the API and parse the response into `FetchLine` instances
-        with console.status("[bold green]Fetching investments from Finary..."):
+        with console.status(f"[bold {TH.ACCENT}]Fetching investments from Finary...", spinner_style=TH.ACCENT):
             response = ff.get_holdings_accounts(session)
             if response["message"] == "OK":
                 for dict_account in response["result"]:

--- a/finalynx/fetch/source_finary.py
+++ b/finalynx/fetch/source_finary.py
@@ -11,7 +11,7 @@ from requests import Session
 from rich.prompt import Confirm
 from rich.tree import Tree
 
-from ..config import ACTIVE_THEME as TH
+from ..config import get_active_theme as TH
 from ..console import console
 from .source_base import SourceBase
 
@@ -126,7 +126,7 @@ class SourceFinary(SourceBase):
 
         # Login to Finary with the existing cookies file or credentials in environment variables and retrieve data
         if os.environ.get("FINARY_EMAIL") and os.environ.get("FINARY_PASSWORD"):
-            with console.status(f"[bold {TH.ACCENT}]Signing in to Finary...", spinner_style=TH.ACCENT):
+            with console.status(f"[bold {TH().ACCENT}]Signing in to Finary...", spinner_style=TH().ACCENT):
                 result = ff.signin()
                 console.log("Signed in to Finary.")
 
@@ -169,7 +169,7 @@ class SourceFinary(SourceBase):
             raise ValueError("Finary signin failed.")
 
         # Call the API and parse the response into `FetchLine` instances
-        with console.status(f"[bold {TH.ACCENT}]Fetching investments from Finary...", spinner_style=TH.ACCENT):
+        with console.status(f"[bold {TH().ACCENT}]Fetching investments from Finary...", spinner_style=TH().ACCENT):
             response = ff.get_holdings_accounts(session)
             if response["message"] == "OK":
                 for dict_account in response["result"]:

--- a/finalynx/parse/parser.py
+++ b/finalynx/parse/parser.py
@@ -1,4 +1,5 @@
 from ..assistant import Assistant
+from ..config import ACTIVE_THEME as TH
 from ..console import console
 
 
@@ -16,7 +17,7 @@ class Parser:
 
     def parse(self) -> Assistant:
         """Convert the input file to a fully configured `Assistant` instance."""
-        with console.status("[bold green]Parsing input file..."):
+        with console.status(f"[bold {TH.ACCENT}]Parsing input file...", spinner_style=TH.ACCENT):
             return self._parse_data()
 
     def _parse_data(self) -> Assistant:

--- a/finalynx/parse/parser.py
+++ b/finalynx/parse/parser.py
@@ -1,5 +1,5 @@
 from ..assistant import Assistant
-from ..config import ACTIVE_THEME as TH
+from ..config import get_active_theme as TH
 from ..console import console
 
 
@@ -17,7 +17,7 @@ class Parser:
 
     def parse(self) -> Assistant:
         """Convert the input file to a fully configured `Assistant` instance."""
-        with console.status(f"[bold {TH.ACCENT}]Parsing input file...", spinner_style=TH.ACCENT):
+        with console.status(f"[bold {TH().ACCENT}]Parsing input file...", spinner_style=TH().ACCENT):
             return self._parse_data()
 
     def _parse_data(self) -> Assistant:

--- a/finalynx/portfolio/folder.py
+++ b/finalynx/portfolio/folder.py
@@ -11,7 +11,7 @@ from rich.tree import Tree
 if TYPE_CHECKING:
     from finalynx.fetch.fetch_line import FetchLine
 
-from ..config import ACTIVE_THEME as TH
+from ..config import get_active_theme as TH
 from ..console import console
 from .bucket import Bucket
 from .constants import AssetClass
@@ -169,7 +169,7 @@ class Folder(Node):
         :returns: A `Tree` instance containing the rendered titles for each `Node` object.
         """
         render = self.render(output_format, **render_args)
-        node = _tree.add(render) if _tree else Tree(render, guide_style=TH.TREE_BRANCHES, hide_root=hide_root)
+        node = _tree.add(render) if _tree else Tree(render, guide_style=TH().TREE_BRANCHES, hide_root=hide_root)
         if self.display == FolderDisplay.EXPANDED:
             for child in self.children:
                 child.tree(output_format=output_format, _tree=node, **render_args)
@@ -267,9 +267,9 @@ class Folder(Node):
         the folder name with a bold font of different color.
         """
         if self.display == FolderDisplay.EXPANDED:
-            return f"[{TH.FOLDER_COLOR} {TH.FOLDER_STYLE}]"
+            return f"[{TH().FOLDER_COLOR} {TH().FOLDER_STYLE}]"
         elif self.display == FolderDisplay.COLLAPSED:
-            return f"[{TH.FOLDER_COLOR}]"
+            return f"[{TH().FOLDER_COLOR}]"
         elif self.display == FolderDisplay.LINE:
             return super()._render_name_color()
         else:

--- a/finalynx/portfolio/folder.py
+++ b/finalynx/portfolio/folder.py
@@ -11,6 +11,7 @@ from rich.tree import Tree
 if TYPE_CHECKING:
     from finalynx.fetch.fetch_line import FetchLine
 
+from ..config import ACTIVE_THEME as TH
 from ..console import console
 from .bucket import Bucket
 from .constants import AssetClass
@@ -168,7 +169,7 @@ class Folder(Node):
         :returns: A `Tree` instance containing the rendered titles for each `Node` object.
         """
         render = self.render(output_format, **render_args)
-        node = _tree.add(render) if _tree else Tree(render, guide_style="grey42", hide_root=hide_root)
+        node = _tree.add(render) if _tree else Tree(render, guide_style=TH.TREE_BRANCHES, hide_root=hide_root)
         if self.display == FolderDisplay.EXPANDED:
             for child in self.children:
                 child.tree(output_format=output_format, _tree=node, **render_args)
@@ -266,9 +267,9 @@ class Folder(Node):
         the folder name with a bold font of different color.
         """
         if self.display == FolderDisplay.EXPANDED:
-            return "[dodger_blue2 bold]"
+            return f"[{TH.FOLDER_COLOR} {TH.FOLDER_STYLE}]"
         elif self.display == FolderDisplay.COLLAPSED:
-            return "[dodger_blue2]"
+            return f"[{TH.FOLDER_COLOR}]"
         elif self.display == FolderDisplay.LINE:
             return super()._render_name_color()
         else:

--- a/finalynx/portfolio/line.py
+++ b/finalynx/portfolio/line.py
@@ -4,8 +4,8 @@ from typing import Dict
 from typing import Optional
 from typing import TYPE_CHECKING
 
-from ..config import ACTIVE_THEME as TH
 from ..config import DEFAULT_CURRENCY
+from ..config import get_active_theme as TH
 from .constants import AssetClass
 from .constants import AssetSubclass
 from .constants import LinePerf
@@ -74,7 +74,7 @@ class Line(Node):
 
     def _render_account_code(self) -> str:
         """:returns: A formatted string representation of this line's envelope."""
-        return f"[{TH.ENVELOPE_CODE}][{self.envelope.code}][/] " if self.envelope else ""
+        return f"[{TH().ENVELOPE_CODE}][{self.envelope.code}][/] " if self.envelope else ""
 
     def to_dict(self) -> Dict[str, Any]:
         return {

--- a/finalynx/portfolio/line.py
+++ b/finalynx/portfolio/line.py
@@ -4,6 +4,7 @@ from typing import Dict
 from typing import Optional
 from typing import TYPE_CHECKING
 
+from ..config import ACTIVE_THEME as TH
 from ..config import DEFAULT_CURRENCY
 from .constants import AssetClass
 from .constants import AssetSubclass
@@ -73,7 +74,7 @@ class Line(Node):
 
     def _render_account_code(self) -> str:
         """:returns: A formatted string representation of this line's envelope."""
-        return f"[{self.envelope.code}] " if self.envelope else ""
+        return f"[{TH.ENVELOPE_CODE}][{self.envelope.code}][/] " if self.envelope else ""
 
     def to_dict(self) -> Dict[str, Any]:
         return {

--- a/finalynx/portfolio/node.py
+++ b/finalynx/portfolio/node.py
@@ -8,8 +8,8 @@ from typing import TYPE_CHECKING
 import numpy as np
 from rich.tree import Tree
 
-from ..config import ACTIVE_THEME as TH
 from ..config import DEFAULT_CURRENCY
+from ..config import get_active_theme as TH
 from .constants import LinePerf
 from .hierarchy import Hierarchy
 from .render import Render
@@ -56,11 +56,11 @@ class Node(Hierarchy, Render):
         # Setup custom aliases for node rendering
         render_aliases: Dict[str, str] = {
             "[text]": "[target_text][prehint] [name] [hint][newline]",
-            "[console]": f"[target][{TH.HINT}][prehint][/] [account_code][name_color][name][/] [{TH.HINT}][hint][newline]",
-            "[console_ideal]": f"[bold {TH.ACCENT}][ideal][/][account_code][name_color][name][/][newline]",
+            "[console]": "[target][prehint] [account_code][name_color][name][/] [hint][newline]",
+            "[console_ideal]": "[bold][ideal][/][account_code][name_color][name][/][newline]",
             "[console_deltas]": "[delta][account_code][name_color][name][/][newline]",
-            "[console_perf]": f"[bold {TH.ACCENT}][perf][/][account_code][name_color][name][/][newline]",
-            "[console_targets]": f"[bold {TH.ACCENT}][goal][/][account_code][name_color][name][/][newline]",
+            "[console_perf]": "[bold][perf][/][account_code][name_color][name][/][newline]",
+            "[console_targets]": "[bold][goal][/][account_code][name_color][name][/][newline]",
             "[text_targets]": "[goal][name][newline]",
             "[dashboard_tree]": "[amount] [currency] [name]",
             "[dashboard_console]": "[bold][target][/][bright_black][prehint][/] [name_color][name][/] [bright_black][hint][/][newline]",
@@ -145,12 +145,12 @@ class Node(Hierarchy, Render):
 
     def _render_hint(self) -> str:
         """:returns: A formatted rendering of a hint message (at the end by default)."""
-        return self.target.hint()
+        return f"[{TH().HINT}]{self.target.hint()}[/]"
 
     def _render_prehint(self) -> str:
         """:returns: A formatted rendering of a pre-hint message (next to the amount by default)."""
         prehint = self.target.prehint()
-        return " " + prehint if prehint else ""
+        return f" [{TH().HINT}]{prehint}[/]" if prehint else ""
 
     def _render_amount(self, hide_amounts: bool = False) -> str:
         """:returns: A formatted rendering of the node amount aligned with the other
@@ -168,11 +168,11 @@ class Node(Hierarchy, Render):
     def _render_goal(self) -> str:
         """:returns: A formatted rendering of the target goal. This could either be an ideal
         amount or ratio to be reached."""
-        return self.target.render_goal()
+        return f"[{TH().ACCENT}]{self.target.render_goal()}"
 
     def _render_ideal(self) -> str:
         """:returns: A formatted rendering of the ideal amount to be invested based on the target."""
-        return self.target.render_ideal()
+        return f"[{TH().ACCENT}]{self.target.render_ideal()}"
 
     def _render_delta(self, align: bool = True, children: Optional[List["Node"]] = None) -> str:
         """Creates a formatted rendering of the delta investment needed to reach the target.
@@ -183,12 +183,12 @@ class Node(Hierarchy, Render):
         delta, check = round(self.get_delta()), self.target.check()
         if delta == 0 or check == Target.RESULT_NONE:
             return ""
-        color = TH.DELTA_POS if delta > 0 else TH.DELTA_NEG
+        color = TH().DELTA_POS if delta > 0 else TH().DELTA_NEG
         children = children if children else (self.parent.children if self.parent and self.parent.children else [])
         max_length = np.max([len(str(abs(round(c.get_delta())))) for c in children]) if children else 0
         max_length = max_length if align else 0
         if check == Target.RESULT_OK:
-            return f"[{TH.DELTA_OK}]{'✓':>{max_length+3}}[/] "
+            return f"[{TH().DELTA_OK}]{'✓':>{max_length+3}}[/] "
         return (
             f"[{color}]{'+' if delta > 0 else '-'}{abs(delta):>{max_length}} {self._render_currency()}[/] "
             # f"[dim white]→  {self.get_ideal():>{max_length}} {self._render_currency()}[/] "
@@ -197,7 +197,7 @@ class Node(Hierarchy, Render):
     def _render_perf(self) -> str:
         """:returns: A formatted rendering of the node's expected yearly performance."""
         perf = self.get_perf()
-        return f"[{'strike ' if perf.skip else ''}bold]{perf.expected:.1f} %[/] " if perf else ""
+        return f"[{'strike ' if perf.skip else ''}bold {TH().ACCENT}]{perf.expected:.1f} %[/] " if perf else ""
 
     def _render_name(self) -> str:
         """:returns: A formatted rendering of the node name."""
@@ -205,7 +205,7 @@ class Node(Hierarchy, Render):
 
     def _render_name_color(self) -> str:
         """:returns: A formatted rendering of the node name's color."""
-        return f"[{TH.TEXT}]"
+        return f"[{TH().TEXT}]"
 
     def _render_newline(self) -> str:
         """:returns: A rendering of the newline if set by the user."""

--- a/finalynx/portfolio/node.py
+++ b/finalynx/portfolio/node.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING
 import numpy as np
 from rich.tree import Tree
 
+from ..config import ACTIVE_THEME as TH
 from ..config import DEFAULT_CURRENCY
 from .constants import LinePerf
 from .hierarchy import Hierarchy
@@ -55,11 +56,11 @@ class Node(Hierarchy, Render):
         # Setup custom aliases for node rendering
         render_aliases: Dict[str, str] = {
             "[text]": "[target_text][prehint] [name] [hint][newline]",
-            "[console]": "[target][dim white][prehint][/] [account_code][name_color][name][/] [dim white][hint][/][newline]",
-            "[console_ideal]": "[bold green][ideal][/][account_code][name_color][name][/][newline]",
+            "[console]": f"[target][{TH.HINT}][prehint][/] [account_code][name_color][name][/] [{TH.HINT}][hint][newline]",
+            "[console_ideal]": f"[bold {TH.ACCENT}][ideal][/][account_code][name_color][name][/][newline]",
             "[console_deltas]": "[delta][account_code][name_color][name][/][newline]",
-            "[console_perf]": "[bold green][perf][/][account_code][name_color][name][/][newline]",
-            "[console_targets]": "[bold green][goal][/][account_code][name_color][name][/][newline]",
+            "[console_perf]": f"[bold {TH.ACCENT}][perf][/][account_code][name_color][name][/][newline]",
+            "[console_targets]": f"[bold {TH.ACCENT}][goal][/][account_code][name_color][name][/][newline]",
             "[text_targets]": "[goal][name][newline]",
             "[dashboard_tree]": "[amount] [currency] [name]",
             "[dashboard_console]": "[bold][target][/][bright_black][prehint][/] [name_color][name][/] [bright_black][hint][/][newline]",
@@ -182,12 +183,12 @@ class Node(Hierarchy, Render):
         delta, check = round(self.get_delta()), self.target.check()
         if delta == 0 or check == Target.RESULT_NONE:
             return ""
-        color = "green" if delta > 0 else "red"
+        color = TH.DELTA_POS if delta > 0 else TH.DELTA_NEG
         children = children if children else (self.parent.children if self.parent and self.parent.children else [])
         max_length = np.max([len(str(abs(round(c.get_delta())))) for c in children]) if children else 0
         max_length = max_length if align else 0
         if check == Target.RESULT_OK:
-            return f"[green]{'✓':>{max_length+3}}[/] "
+            return f"[{TH.DELTA_OK}]{'✓':>{max_length+3}}[/] "
         return (
             f"[{color}]{'+' if delta > 0 else '-'}{abs(delta):>{max_length}} {self._render_currency()}[/] "
             # f"[dim white]→  {self.get_ideal():>{max_length}} {self._render_currency()}[/] "
@@ -196,7 +197,7 @@ class Node(Hierarchy, Render):
     def _render_perf(self) -> str:
         """:returns: A formatted rendering of the node's expected yearly performance."""
         perf = self.get_perf()
-        return f"[{'strike ' if perf.skip else ''}bold green]{perf.expected:.1f} %[/] " if perf else ""
+        return f"[{'strike ' if perf.skip else ''}bold]{perf.expected:.1f} %[/] " if perf else ""
 
     def _render_name(self) -> str:
         """:returns: A formatted rendering of the node name."""
@@ -204,7 +205,7 @@ class Node(Hierarchy, Render):
 
     def _render_name_color(self) -> str:
         """:returns: A formatted rendering of the node name's color."""
-        return "[black]"
+        return f"[{TH.TEXT}]"
 
     def _render_newline(self) -> str:
         """:returns: A rendering of the newline if set by the user."""

--- a/finalynx/portfolio/targets.py
+++ b/finalynx/portfolio/targets.py
@@ -4,6 +4,7 @@ from typing import TYPE_CHECKING
 
 import numpy as np
 
+from ..config import ACTIVE_THEME as TH
 from .hierarchy import Hierarchy
 
 if TYPE_CHECKING:
@@ -13,13 +14,13 @@ if TYPE_CHECKING:
 class Target(Hierarchy):
     """Abstract class that defines an objective for a `Node` in the Portfolio tree."""
 
-    RESULT_NOK = {"name": "NOK", "symbol": "×", "color": "red"}
-    RESULT_OK = {"name": "OK", "symbol": "✓", "color": "green"}
-    RESULT_TOLERATED = {"name": "Tolerated", "symbol": "≈", "color": "yellow"}
-    RESULT_INVEST = {"name": "Invest", "symbol": "↗", "color": "red"}
-    RESULT_DEVEST = {"name": "Devest", "symbol": "↘", "color": "magenta"}
-    RESULT_START = {"name": "Start", "symbol": "↯", "color": "cyan"}
-    RESULT_NONE = {"name": "No target", "symbol": "‣", "color": "black"}
+    RESULT_NOK = {"name": "NOK", "symbol": "×", "color": TH.TARGET_NOK}
+    RESULT_OK = {"name": "OK", "symbol": "✓", "color": TH.TARGET_OK}
+    RESULT_TOLERATED = {"name": "Tolerated", "symbol": "≈", "color": TH.TARGET_TOLERATED}
+    RESULT_INVEST = {"name": "Invest", "symbol": "↗", "color": TH.TARGET_INVEST}
+    RESULT_DEVEST = {"name": "Devest", "symbol": "↘", "color": TH.TARGET_DEVEST}
+    RESULT_START = {"name": "Start", "symbol": "↯", "color": TH.TARGET_START}
+    RESULT_NONE = {"name": "No target", "symbol": "‣", "color": TH.TARGET_NONE}
 
     def __init__(self) -> None:
         """Abstract Target class that holds the Node parent using this instance and provides
@@ -73,18 +74,19 @@ class Target(Hierarchy):
         # Otherwise, simply get the parent's value
         return self.parent.parent.get_amount()
 
-    def render_amount(self, hide_amount: bool = False, n_characters: int = 0) -> str:
-        """Check for the parent's amount against the target logic and format the amount based on the target recommendation.
-        :param hide_amount: Replace the amounts by simple dots (easier to share the result), defaults to False.
-        :param n_characters: Used by `Node` objects to align the amount with other nodes' renders.
-        :returns: A string with a righ-formatted render of the parent's amount based on the target recommendation.
-        """
-        result = self.check()
-        result = result if result != True else Target.RESULT_START  # type: ignore # noqa: E712 TODO weird bug??? Workaround for now
-        number = f"{round(self.get_amount()):>{n_characters}}" if not hide_amount else "···"
-        return (
-            f'[{result["color"]}]{result["symbol"]} {number} {self._render_currency()}[/][dim white]{self.prehint()}[/]'
-        )
+    # TODO deprecated?
+    # def render_amount(self, hide_amount: bool = False, n_characters: int = 0) -> str:
+    #     """Check for the parent's amount against the target logic and format the amount based on the target recommendation.
+    #     :param hide_amount: Replace the amounts by simple dots (easier to share the result), defaults to False.
+    #     :param n_characters: Used by `Node` objects to align the amount with other nodes' renders.
+    #     :returns: A string with a righ-formatted render of the parent's amount based on the target recommendation.
+    #     """
+    #     result = self.check()
+    #     result = result if result != True else Target.RESULT_START  # type: ignore # noqa: E712 TODO weird bug??? Workaround for now
+    #     number = f"{round(self.get_amount()):>{n_characters}}" if not hide_amount else "···"
+    #     return (
+    #         f'[{result["color"]}]{result["symbol"]} {number} {self._render_currency()}[/][dim white]{self.prehint()}[/]'
+    #     )
 
     def render_ideal(self) -> str:
         """Ideal amount to be reached based on the current target and node

--- a/finalynx/portfolio/targets.py
+++ b/finalynx/portfolio/targets.py
@@ -4,7 +4,7 @@ from typing import TYPE_CHECKING
 
 import numpy as np
 
-from ..config import ACTIVE_THEME as TH
+from ..config import get_active_theme as TH
 from .hierarchy import Hierarchy
 
 if TYPE_CHECKING:
@@ -14,13 +14,13 @@ if TYPE_CHECKING:
 class Target(Hierarchy):
     """Abstract class that defines an objective for a `Node` in the Portfolio tree."""
 
-    RESULT_NOK = {"name": "NOK", "symbol": "×", "color": TH.TARGET_NOK}
-    RESULT_OK = {"name": "OK", "symbol": "✓", "color": TH.TARGET_OK}
-    RESULT_TOLERATED = {"name": "Tolerated", "symbol": "≈", "color": TH.TARGET_TOLERATED}
-    RESULT_INVEST = {"name": "Invest", "symbol": "↗", "color": TH.TARGET_INVEST}
-    RESULT_DEVEST = {"name": "Devest", "symbol": "↘", "color": TH.TARGET_DEVEST}
-    RESULT_START = {"name": "Start", "symbol": "↯", "color": TH.TARGET_START}
-    RESULT_NONE = {"name": "No target", "symbol": "‣", "color": TH.TARGET_NONE}
+    RESULT_NOK = {"name": "NOK", "symbol": "×"}
+    RESULT_OK = {"name": "OK", "symbol": "✓"}
+    RESULT_TOLERATED = {"name": "Tolerated", "symbol": "≈"}
+    RESULT_INVEST = {"name": "Invest", "symbol": "↗"}
+    RESULT_DEVEST = {"name": "Devest", "symbol": "↘"}
+    RESULT_START = {"name": "Start", "symbol": "↯"}
+    RESULT_NONE = {"name": "No target", "symbol": "‣"}
 
     def __init__(self) -> None:
         """Abstract Target class that holds the Node parent using this instance and provides
@@ -108,7 +108,15 @@ class Target(Hierarchy):
 
     def _render_target_color(self) -> str:
         """:returns: The color associated to the target recommentation."""
-        return self.check()["color"]
+        return {
+            Target.RESULT_NOK["name"]: TH().TARGET_NOK,
+            Target.RESULT_OK["name"]: TH().TARGET_OK,
+            Target.RESULT_TOLERATED["name"]: TH().TARGET_TOLERATED,
+            Target.RESULT_INVEST["name"]: TH().TARGET_INVEST,
+            Target.RESULT_DEVEST["name"]: TH().TARGET_DEVEST,
+            Target.RESULT_START["name"]: TH().TARGET_START,
+            Target.RESULT_NONE["name"]: TH().TARGET_NONE,
+        }[self.check()["name"]]
 
     def _render_currency(self) -> str:
         """:returns: This parent's currency symbol, used for target render methods."""

--- a/finalynx/theme.py
+++ b/finalynx/theme.py
@@ -1,3 +1,8 @@
+"""
+DOCUMENTATION
+- See available colors: https://rich.readthedocs.io/en/stable/appendix/colors.html#appendix-colors
+- See available styles: https://rich.readthedocs.io/en/stable/style.html
+"""
 from dataclasses import dataclass
 from typing import Dict
 from typing import Type
@@ -41,6 +46,10 @@ LightTheme = Theme
 @dataclass
 class DarkTheme(Theme):
     TEXT = "white"
+    HINT = "bright black"
+    ENVELOPE_CODE = "bright black"
+    TARGET_NONE = "white"
+    PANEL = "white"
 
 
 # List predefined themes, used by `Assistant` to search for class definitions

--- a/finalynx/theme.py
+++ b/finalynx/theme.py
@@ -1,0 +1,36 @@
+from dataclasses import dataclass
+from typing import Dict
+from typing import Type
+
+
+@dataclass
+class Theme:
+    # Main elements
+    DEFAULT_TEXT = "black"
+    HINT = "dim white"
+
+    # Folders
+    FOLDER_COLOR = "blue"
+    FOLDER_STYLE = "bold"
+
+    # Targets
+    TARGET_NONE = "green"
+    TARGET_OK = "green"
+    TARGET_NOK = "red"
+    TARGET_TOLERATED = "yellow"
+
+
+# Shortcut for a more intuitive usage
+LightTheme = Theme
+
+
+@dataclass
+class DarkTheme(Theme):
+    DEFAULT_TEXT = "white"
+
+
+# List predefined themes, used by `Assistant` to search for class definitions
+AVAILABLE_THEMES: Dict[str, Type[Theme]] = {
+    "light": LightTheme,
+    "dark": DarkTheme,
+}

--- a/finalynx/theme.py
+++ b/finalynx/theme.py
@@ -18,10 +18,10 @@ class Theme:
     HINT = "dim white"
     FOLDER_COLOR = "dodger_blue2"
     FOLDER_STYLE = "bold"
-    ENVELOPE_CODE = "dim white"  # TODO?
+    ENVELOPE_CODE = "dim white"
 
     # Targets
-    TARGET_NONE = TEXT
+    TARGET_NONE = "black"
     TARGET_START = "cyan"
     TARGET_OK = "green"
     TARGET_NOK = "red"
@@ -32,11 +32,11 @@ class Theme:
     # Deltas
     DELTA_POS = "green"
     DELTA_NEG = "red"
-    DELTA_OK = DELTA_POS
+    DELTA_OK = "green"
 
     # Decorations
     TREE_BRANCHES = "grey42"
-    PANEL = TEXT
+    PANEL = "black"
 
 
 # Shortcut for a more intuitive usage

--- a/finalynx/theme.py
+++ b/finalynx/theme.py
@@ -6,18 +6,32 @@ from typing import Type
 @dataclass
 class Theme:
     # Main elements
-    DEFAULT_TEXT = "black"
-    HINT = "dim white"
+    TEXT = "black"
+    ACCENT = "deep_sky_blue2"
 
-    # Folders
-    FOLDER_COLOR = "blue"
+    # Main tree elements
+    HINT = "dim white"
+    FOLDER_COLOR = "dodger_blue2"
     FOLDER_STYLE = "bold"
+    ENVELOPE_CODE = "dim white"  # TODO?
 
     # Targets
-    TARGET_NONE = "green"
+    TARGET_NONE = TEXT
+    TARGET_START = "cyan"
     TARGET_OK = "green"
     TARGET_NOK = "red"
     TARGET_TOLERATED = "yellow"
+    TARGET_INVEST = "red"
+    TARGET_DEVEST = "magenta"
+
+    # Deltas
+    DELTA_POS = "green"
+    DELTA_NEG = "red"
+    DELTA_OK = DELTA_POS
+
+    # Decorations
+    TREE_BRANCHES = "grey42"
+    PANEL = TEXT
 
 
 # Shortcut for a more intuitive usage
@@ -26,7 +40,7 @@ LightTheme = Theme
 
 @dataclass
 class DarkTheme(Theme):
-    DEFAULT_TEXT = "white"
+    TEXT = "white"
 
 
 # List predefined themes, used by `Assistant` to search for class definitions

--- a/finalynx/theme.py
+++ b/finalynx/theme.py
@@ -46,8 +46,8 @@ LightTheme = Theme
 @dataclass
 class DarkTheme(Theme):
     TEXT = "white"
-    HINT = "bright black"
-    ENVELOPE_CODE = "bright black"
+    HINT = "dim white"
+    ENVELOPE_CODE = "dim white"
     TARGET_NONE = "white"
     PANEL = "white"
 

--- a/finalynx/usage.py
+++ b/finalynx/usage.py
@@ -31,6 +31,8 @@ Options:
 {main_filter(main_options)}
   dashboard            Launch an interactive web dashboard!
 
+  -t --theme=string    Choose a predefined color theme for the console output (light or dark)
+
   --no-export          Don't export to JSON
   --export-dir=path    Path to a folder where the file will be saved
 

--- a/finalynx/usage.py
+++ b/finalynx/usage.py
@@ -42,7 +42,6 @@ Options:
   targets              Shortcut to --format="[console_targets]" (show target values instead of amounts)
   deltas               Shortcut to --format="[console_deltas]" (show deltas instead of amounts)
   perf                 Shortcut to --format="[console_perf]" (show expected performances)
-  text                 Shortcut to --format="[console_text]" (no colors)
 
   -s --sources=string  Comma-separated list of sources to activate, defaults to "finary" only
 


### PR DESCRIPTION
### Description
Set a custom set of colors for each element rendered to the console. New dark theme: 

<img src="https://github.com/MadeInPierre/finalynx/assets/12670280/aaf072f2-c434-487b-8e21-8ef4b1109e03" width="500px"/>

In addition to the original light theme:

<img src="https://github.com/MadeInPierre/finalynx/assets/12670280/58bd51b0-7bb8-4b6d-afb5-49498a859993" width="500px"/>

And seems alright with VSCode:

<img src="https://github.com/MadeInPierre/finalynx/assets/12670280/ed799d10-c285-4627-a243-d41e0abee90e" width="500px"/>



### Actions
- Closes #77
- Resolves weird console colors reported in #75 

### Usage

Use one of the predefined themes (light or dark), default is light:
```bash
python your_config --theme="dark"  # or light
```

Set your own custom theme in `your_config.py`, see the `LightTheme` class for references:

```python
from finalynx import Theme

class MyTheme:
    TEXT = "white"
    FOLDER_COLOR="cyan"
    ...

portfolio = Portfolio(...)
assistant = Assistant(..., theme=MyTheme())
assistant.run()
```

### Steps
- [X] Create the theme class & command parsing
- [x] Create theme variables for each element
- [x] Connect the variables everuwhere
